### PR TITLE
Allow multiple Telegram admins

### DIFF
--- a/Function/db.py
+++ b/Function/db.py
@@ -6,7 +6,7 @@ def DEF_GET_BOT_TOKEN():
     conn = sqlite3.connect('holder.db')
     cursor = conn.cursor()
     cursor.execute('''SELECT token FROM bot''')
-    second_column_value = cursor.fetchone()[0] 
+    second_column_value = cursor.fetchone()[0]
     conn.close()
     return second_column_value
 
@@ -20,6 +20,14 @@ def DEF_CHECK_BOSS(CHATID):
         return True
     else:
         return False
+
+def DEF_BOSS_CHATIDS():
+    conn = sqlite3.connect('holder.db')
+    cursor = conn.cursor()
+    cursor.execute("SELECT chatid FROM users WHERE role='boss'")
+    IDS = [row[0] for row in cursor.fetchall()]
+    conn.close()
+    return IDS
 
 def DEF_CHECK_STEP(CHATID) :
     conn = sqlite3.connect('holder.db')
@@ -60,22 +68,22 @@ def DEF_PANEL_ACCESS(PANEL_USER, PANEL_PASS, PANEL_DOMAIN) :
 def DEF_MONITORING_DATA():
     conn = sqlite3.connect('holder.db')
     cursor = conn.cursor()
-    cursor.execute('''SELECT * FROM monitoring''')
+    cursor.execute('''SELECT status, check_normal, check_error FROM monitoring''')
     USER_DATA = cursor.fetchone()
     conn.close()
     return USER_DATA
 
-def DEF_CHANGE_NODE_STATUS(CHATID , STATUS) :
+def DEF_CHANGE_NODE_STATUS(STATUS) :
     conn = sqlite3.connect('holder.db')
     cursor = conn.cursor()
-    cursor.execute("UPDATE monitoring SET status = ? WHERE chatid = ?", (STATUS, CHATID))
+    cursor.execute("UPDATE monitoring SET status = ?", (STATUS,))
     conn.commit()
     conn.close()
 
-def DEF_NODE_STATUS(CHATID , ROW , STATUS) :
+def DEF_NODE_STATUS(ROW , STATUS) :
     conn = sqlite3.connect('holder.db')
     cursor = conn.cursor()
-    cursor.execute(f"UPDATE monitoring SET {ROW} = ? WHERE chatid = ?", (STATUS, CHATID))
+    cursor.execute(f"UPDATE monitoring SET {ROW} = ?", (STATUS,))
     conn.commit()
     conn.close()
 
@@ -118,31 +126,23 @@ def DEF_TEMPLATES_DATA_ALL(TEXT):
     conn.close()
     return result
 
-def DEF_MESSAGER_IMPORT_DATA():
+def DEF_MESSAGER_STATUS():
     conn = sqlite3.connect('holder.db')
     cursor = conn.cursor()
-    cursor.execute('''SELECT * FROM messages''')
+    cursor.execute('''SELECT status FROM messages''')
     USER_DATA = cursor.fetchone()
     conn.close()
-    return USER_DATA
+    return USER_DATA[0] if USER_DATA else None
 
-def DEF_GET_MESSAGE_STATUS(CHATID):
-    conn = sqlite3.connect('holder.db')
-    cursor = conn.cursor()
-    cursor.execute('''SELECT status FROM messages WHERE chatid = ?''', (CHATID,))
-    USER_DATA = cursor.fetchone()
-    conn.close()
-    if USER_DATA:
-        return USER_DATA[0]
-    else:
-        return None
+def DEF_GET_MESSAGE_STATUS():
+    return DEF_MESSAGER_STATUS()
 
 def DEF_CHANGE_MESSAGER_STATUS(CHATID):
-    OLD_STATUS = DEF_GET_MESSAGE_STATUS(CHATID)
+    OLD_STATUS = DEF_GET_MESSAGE_STATUS()
     conn = sqlite3.connect('holder.db')
     cursor = conn.cursor()
-    if OLD_STATUS == "on" :    
-        cursor.execute('''UPDATE messages SET status = ? WHERE chatid = ?''', ("off", CHATID))
+    if OLD_STATUS == "on" :
+        cursor.execute('''UPDATE messages SET status = ?''', ("off",))
         conn.commit()
         conn.close()
         TEXT = "<b>✅ Your status is off.</b>"
@@ -162,7 +162,7 @@ def DEF_CHANGE_MESSAGER_STATUS(CHATID):
             else :
                 FOUND = False
             if FOUND :
-                cursor.execute('''UPDATE messages SET status = ? WHERE chatid = ?''', ("on", CHATID))
+                cursor.execute('''UPDATE messages SET status = ?''', ("on",))
                 conn.commit()
                 conn.close()
                 TEXT = "<b>✅ Your status is on.</b>"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Holder Bot is a quick and simple bot designed to address the issue of the lack o
 
 To use the holderbot , you will need the following information:
 1. **Name:** You can enter any name you prefer.
-2. **Chat ID:** You need to obtain this from the [@chatIDrobot](https://t.me/chatIDrobot).
+2. **Chat ID(s):** You need to obtain this from the [@chatIDrobot](https://t.me/chatIDrobot). You can provide multiple numeric IDs separated by spaces so each account can control the bot.
 3. **Bot Token:** You need to obtain this from the [@botfather](https://t.me/BotFather).
 4. **Panel Username:** Enter your panel sudo admin username.
 5. **Panel Password:** Enter your panel sudo admin password.
@@ -78,6 +78,24 @@ sudo bash -c "$(curl -sL https://github.com/erfjab/holderbot/raw/main/restart.sh
 ```
 sudo bash -c "$(curl -sL https://github.com/erfjab/holderbot/raw/main/uninstall.sh)"
 ```
+
+### Managing admin IDs after installation
+
+If you need to add another Telegram admin later, run:
+
+```
+sqlite3 holder.db "INSERT INTO users (chatid, role, name, username, password, domain, step) SELECT NEW_CHAT_ID, role, name, username, password, domain, 'None' FROM users WHERE role='boss' LIMIT 1;"
+```
+
+Replace `NEW_CHAT_ID` with the numeric ID you want to add.
+
+To remove an admin, run:
+
+```
+sqlite3 holder.db "DELETE FROM users WHERE chatid=CHAT_ID;"
+```
+
+Replace `CHAT_ID` with the ID you wish to remove.
 
 # How to use the bot? (video) # 
 

--- a/expired.py
+++ b/expired.py
@@ -13,9 +13,10 @@ app = Client(
 with app :
     while True :
         try :
-            BOSS_CHATID , STATUS = DEF_MESSAGER_IMPORT_DATA()
+            BOSS_CHATIDS = DEF_BOSS_CHATIDS()
+            STATUS = DEF_MESSAGER_STATUS()
             if STATUS == "on":
-                PANEL_USER, PANEL_PASS, PANEL_DOMAIN = DEF_IMPORT_DATA (BOSS_CHATID)
+                PANEL_USER, PANEL_PASS, PANEL_DOMAIN = DEF_IMPORT_DATA (BOSS_CHATIDS[0])
                 PANEL_TOKEN = DEF_PANEL_ACCESS(PANEL_USER, PANEL_PASS, PANEL_DOMAIN)
                 URL = f"{PANEL_DOMAIN}/api/users?status=expired"
                 RESPONCE = requests.get(url=URL , headers=PANEL_TOKEN , verify=False )
@@ -29,14 +30,17 @@ with app :
                             DATA = {"proxies":{"shadowsocks":{}},"inbounds" : {'shadowsocks': ['Holderbot']}}
                             RESPONCE = requests.put(url=URL , json=DATA , headers=PANEL_TOKEN , verify=False)
                             if RESPONCE.status_code == 200 :
-                                app.send_message(chat_id=BOSS_CHATID , text=f"<b>✅ (Checker) Boss! user <code>{USERNAME}</code> is expired,\nI have set the messages.</b>" , parse_mode=enums.ParseMode.HTML , disable_notification=True)
+                                for CHAT_ID in BOSS_CHATIDS:
+                                    app.send_message(chat_id=CHAT_ID , text=f"<b>✅ (Checker) Boss! user <code>{USERNAME}</code> is expired,\nI have set the messages.</b>" , parse_mode=enums.ParseMode.HTML , disable_notification=True)
                             else :
-                                app.send_message(chat_id=BOSS_CHATID , text=f"<b>❗ (Checker) Boss! user <code>{USERNAME}</code> is expired,\nbut I can't set the messages.\n\n<pre>{RESPONCE.text}</pre></b>" , parse_mode=enums.ParseMode.HTML , disable_notification=True)                                
+                                for CHAT_ID in BOSS_CHATIDS:
+                                    app.send_message(chat_id=CHAT_ID , text=f"<b>❗ (Checker) Boss! user <code>{USERNAME}</code> is expired,\nbut I can't set the messages.\n\n<pre>{RESPONCE.text}</pre></b>" , parse_mode=enums.ParseMode.HTML , disable_notification=True)
                         time.sleep(0.5)
                 time.sleep(5)
             else :
                 time.sleep(60)
         except Exception as e :
-            app.send_message(chat_id=BOSS_CHATID , text=f"<b>❌ (Checker) Expirider Error :</b>\n<pre>{str(e)}</pre>" , parse_mode=enums.ParseMode.HTML)
+            for CHAT_ID in BOSS_CHATIDS:
+                app.send_message(chat_id=CHAT_ID , text=f"<b>❌ (Checker) Expirider Error :</b>\n<pre>{str(e)}</pre>" , parse_mode=enums.ParseMode.HTML)
             time.sleep(60)
             pass

--- a/holder.py
+++ b/holder.py
@@ -86,7 +86,7 @@ async def holderbot(client: Client, message: Message) :
                 UPDATE_STEP = DEF_UPDATE_STEP(MESSAGE_CHATID,"nodes | wait to select node")
 
             elif MESSAGE_TEXT == "🎛 Monitoring" :
-                BOSS_CHATID , NODE_STATUS , CHECK_NORMAL , CHECK_ERROR = DEF_MONITORING_DATA()
+                NODE_STATUS , CHECK_NORMAL , CHECK_ERROR = DEF_MONITORING_DATA()
                 if NODE_STATUS == "off" :
                     TEXT = f"<b>🔴 Monitoring is <code>off</code></b>"
                     KEYBOARD_MONITORING = KEYBOARD_OFF_MONITORING
@@ -107,7 +107,7 @@ async def holderbot(client: Client, message: Message) :
                 UPDATE_STEP = DEF_UPDATE_STEP(MESSAGE_CHATID,"create | wait to select command")
 
             elif MESSAGE_TEXT == "🎖 Notice" :
-                await client.send_message(chat_id=MESSAGE_CHATID , text=f"<b>Welcome to the Messages section! This feature has been added with sponsorship the <a href='https://t.me/GrayServer'>Gray</a> collection.❤️ You can visit the Gray collection channel and bot for purchasing servers on an hourly and monthly basis, with a wide variety of locations and specifications, accompanied by clean IPs at the lowest prices.\n\nTo utilize this feature, you first need to create an inbound according to the tutorial on GitHub Wiki or the Telegram channel tutorial for Holderbot. Then, in the host setting section of that inbound, write down the texts you desire to be displayed to the user upon completion of the configuration update.\n\nYour Messages is <code>{DEF_GET_MESSAGE_STATUS(MESSAGE_CHATID)}</code></b>" , reply_markup=KEYBOARD_MESSAGES , parse_mode=enums.ParseMode.HTML , disable_web_page_preview=True )
+                await client.send_message(chat_id=MESSAGE_CHATID , text=f"<b>Welcome to the Messages section! This feature has been added with sponsorship the <a href='https://t.me/GrayServer'>Gray</a> collection.❤️ You can visit the Gray collection channel and bot for purchasing servers on an hourly and monthly basis, with a wide variety of locations and specifications, accompanied by clean IPs at the lowest prices.\n\nTo utilize this feature, you first need to create an inbound according to the tutorial on GitHub Wiki or the Telegram channel tutorial for Holderbot. Then, in the host setting section of that inbound, write down the texts you desire to be displayed to the user upon completion of the configuration update.\n\nYour Messages is <code>{DEF_GET_MESSAGE_STATUS()}</code></b>" , reply_markup=KEYBOARD_MESSAGES , parse_mode=enums.ParseMode.HTML , disable_web_page_preview=True )
                 UPDATE_STEP = DEF_UPDATE_STEP(MESSAGE_CHATID,"message | wait to select command")
                                 
             else :
@@ -315,11 +315,11 @@ async def holderbot(client: Client, message: Message) :
                 if CHECK_STEP == "monitoring | wait to select command" :
 
                     if MESSAGE_TEXT == "🔴 Disable monitoring" :
-                        CHANGE = DEF_CHANGE_NODE_STATUS(MESSAGE_CHATID,"off")
+                        CHANGE = DEF_CHANGE_NODE_STATUS("off")
                         await client.send_message(chat_id=MESSAGE_CHATID , text="<b>✅ Your Monitoring is disabled.</b>" , reply_markup=KEYBOARD_OFF_MONITORING , parse_mode=enums.ParseMode.HTML , disable_web_page_preview=True )
 
                     elif MESSAGE_TEXT == "🟢 Monitoring activation" :
-                        CHANGE = DEF_CHANGE_NODE_STATUS(MESSAGE_CHATID,"on")
+                        CHANGE = DEF_CHANGE_NODE_STATUS("on")
                         await client.send_message(chat_id=MESSAGE_CHATID , text="<b>✅ Your Monitoring is activated.</b>" , reply_markup=KEYBOARD_ON_MONITORING , parse_mode=enums.ParseMode.HTML , disable_web_page_preview=True )
                     
                     elif MESSAGE_TEXT == "⏱ Normal timer" :
@@ -335,7 +335,7 @@ async def holderbot(client: Client, message: Message) :
                     if CHECK_STEP.startswith("monitoring | timer") :
                         DB_ROW = STEP_SPLIT[3]
                         if len(MESSAGES_SPLIT) == 1 and MESSAGE_TEXT.isnumeric() :
-                            CHANGE = DEF_NODE_STATUS(MESSAGE_CHATID , DB_ROW , MESSAGE_TEXT)
+                            CHANGE = DEF_NODE_STATUS(DB_ROW , MESSAGE_TEXT)
                             await client.send_message(chat_id=MESSAGE_CHATID , text=f"<b>✅ Your {DB_ROW} timer is changed.</b>" , reply_markup=KEYBOARD_ON_MONITORING , parse_mode=enums.ParseMode.HTML , disable_web_page_preview=True )
                             UPDATE_STEP = DEF_UPDATE_STEP(MESSAGE_CHATID,"monitoring | wait to select command")
                 

--- a/holderbot.sh
+++ b/holderbot.sh
@@ -43,7 +43,7 @@ pip install -U pyrogram tgcrypto requests Pillow qrcode[pil] persiantools pytz p
 sudo apt-get install -y sqlite3
 #defining variables
 name=""
-chatid=""
+chatids=()
 token=""
 user=""
 password=""
@@ -65,11 +65,13 @@ function getinfo() {
     done
     
 
-    chatid=""
-    while [[ ! "$chatid" =~ ^[0-9]+$ ]]; do
-        read -p "Please enter telegram chatid : " chatid
-        if [[ ! "$chatid" =~ ^[0-9]+$ ]]; then
-            echo "Chat ID must be a number. Please enter a valid number."
+    chatids=()
+    while [ ${#chatids[@]} -eq 0 ]; do
+        read -p "Please enter telegram chat id(s) (space-separated): " chatids_input
+        if [[ $chatids_input =~ ^[0-9]+([[:space:]][0-9]+)*$ ]]; then
+            read -a chatids <<< "$chatids_input"
+        else
+            echo "Chat IDs must be numbers separated by spaces. Please enter valid IDs."
         fi
     done
 
@@ -129,7 +131,7 @@ function getinfo() {
 function checkinfo() {
     clear && echo -e "\\n      Checking information...      \\n\\n"
     echo "Name: $name"
-    echo "Telegram Chat ID: $chatid"
+    echo "Telegram Chat ID(s): ${chatids[*]}"
     echo "Telegram Bot Token: $token"
     echo "Panel Sudo Username: $user"
     echo "Panel Sudo Password: $password"
@@ -160,14 +162,12 @@ done
 clear && echo -e "\n      Creating database...      \n\n" && yes '-' | head -n 50 | tr -d '\n\n' && echo
 rm holder.db || true
 while true; do
-    sqlite3 holder.db <<EOF
+    SQL=$(cat <<EOF
 CREATE TABLE IF NOT EXISTS bot
-    (chatid INTEGER PRIMARY KEY,
-     token TEXT);
+    (token TEXT);
 
 CREATE TABLE IF NOT EXISTS monitoring
-    (chatid INTEGER PRIMARY KEY,
-     status TEXT,
+    (status TEXT,
      check_normal INTEGER,
      check_error INTEGER);
 
@@ -188,14 +188,18 @@ CREATE TABLE IF NOT EXISTS users
      step TEXT);
 
 CREATE TABLE IF NOT EXISTS messages
-    (chatid INTEGER PRIMARY KEY,
-    status TEXT);
+    (status TEXT);
 
-INSERT INTO messages (chatid, status) VALUES ('$chatid', 'off');
-INSERT INTO users (chatid, role, name, username, password, domain, step) VALUES ('$chatid', 'boss', '$name', '$user', '$password', '$domain', 'None');
-INSERT INTO monitoring (chatid, status, check_normal, check_error) VALUES ('$chatid', 'on', '10', '100');
-INSERT INTO bot (chatid, token) VALUES ('$chatid', '$token');
+INSERT INTO messages (status) VALUES ('off');
+INSERT INTO monitoring (status, check_normal, check_error) VALUES ('on', '10', '100');
+INSERT INTO bot (token) VALUES ('$token');
 EOF
+    )
+    sqlite3 holder.db <<< "$SQL"
+
+    for cid in "${chatids[@]}"; do
+        sqlite3 holder.db "INSERT INTO users (chatid, role, name, username, password, domain, step) VALUES ('$cid', 'boss', '$name', '$user', '$password', '$domain', 'None');"
+    done
 
     if [[ $? -eq 0 ]]; then
         echo "Database setup successful."

--- a/limiteder.py
+++ b/limiteder.py
@@ -13,9 +13,10 @@ app = Client(
 with app :
     while True :
         try :
-            BOSS_CHATID , STATUS = DEF_MESSAGER_IMPORT_DATA()
+            BOSS_CHATIDS = DEF_BOSS_CHATIDS()
+            STATUS = DEF_MESSAGER_STATUS()
             if STATUS == "on" :
-                PANEL_USER, PANEL_PASS, PANEL_DOMAIN = DEF_IMPORT_DATA (BOSS_CHATID)
+                PANEL_USER, PANEL_PASS, PANEL_DOMAIN = DEF_IMPORT_DATA (BOSS_CHATIDS[0])
                 PANEL_TOKEN = DEF_PANEL_ACCESS(PANEL_USER, PANEL_PASS, PANEL_DOMAIN)
                 URL = f"{PANEL_DOMAIN}/api/users?status=limited"
                 RESPONCE = requests.get(url=URL , headers=PANEL_TOKEN , verify=False)
@@ -29,14 +30,17 @@ with app :
                             DATA = {"proxies":{"shadowsocks":{}},"inbounds" : {'shadowsocks': ['Holderbot']}}
                             RESPONCE = requests.put(url=URL , json=DATA , headers=PANEL_TOKEN , verify=False)
                             if RESPONCE.status_code == 200 :
-                                app.send_message(chat_id=BOSS_CHATID , text=f"<b>✅ (Checker) Boss! user <code>{USERNAME}</code> is limited,\nI have set the messages.</b>" , parse_mode=enums.ParseMode.HTML , disable_notification=True)
+                                for CHAT_ID in BOSS_CHATIDS:
+                                    app.send_message(chat_id=CHAT_ID , text=f"<b>✅ (Checker) Boss! user <code>{USERNAME}</code> is limited,\nI have set the messages.</b>" , parse_mode=enums.ParseMode.HTML , disable_notification=True)
                             else :
-                                app.send_message(chat_id=BOSS_CHATID , text=f"<b>❗ (Checker) Boss! user <code>{USERNAME}</code> is limited,\nbut I can't set the messages.\n\n<pre>{RESPONCE.text}</pre></b>" , parse_mode=enums.ParseMode.HTML , disable_notification=True)                                
+                                for CHAT_ID in BOSS_CHATIDS:
+                                    app.send_message(chat_id=CHAT_ID , text=f"<b>❗ (Checker) Boss! user <code>{USERNAME}</code> is limited,\nbut I can't set the messages.\n\n<pre>{RESPONCE.text}</pre></b>" , parse_mode=enums.ParseMode.HTML , disable_notification=True)
                         time.sleep(0.5)
                 time.sleep(5)
             else :
                 time.sleep(60)
         except Exception as e :
-            app.send_message(chat_id=BOSS_CHATID , text=f"<b>❌ (Checker) limiteder Error :</b>\n<pre>{str(e)}</pre>" , parse_mode=enums.ParseMode.HTML , disable_notification=True)
+            for CHAT_ID in BOSS_CHATIDS:
+                app.send_message(chat_id=CHAT_ID , text=f"<b>❌ (Checker) limiteder Error :</b>\n<pre>{str(e)}</pre>" , parse_mode=enums.ParseMode.HTML , disable_notification=True)
             time.sleep(60)
             pass

--- a/monitoring.py
+++ b/monitoring.py
@@ -17,8 +17,9 @@ with app :
 
     while True :
         try :
-            BOSS_CHATID , NODE_STATUS , CHECK_NORMAL , CHECK_ERROR = DEF_MONITORING_DATA ()
-            PANEL_USER, PANEL_PASS, PANEL_DOMAIN = DEF_IMPORT_DATA (BOSS_CHATID)
+            BOSS_CHATIDS = DEF_BOSS_CHATIDS()
+            NODE_STATUS , CHECK_NORMAL , CHECK_ERROR = DEF_MONITORING_DATA ()
+            PANEL_USER, PANEL_PASS, PANEL_DOMAIN = DEF_IMPORT_DATA (BOSS_CHATIDS[0])
             if NODE_STATUS == "on" :
                 
                 NODE_HAVE_A_PROBLEM = False
@@ -36,14 +37,17 @@ with app :
                             TEXT = f"<b>❗ (Checker) boss of one of the servers crashed. To prevent spamming, server monitoring has been stopped and will be restarted after <code>{CHECK_ERROR}</code> seconds.</b>"
                             TEXT += f"\n\n<b>NODE NAME : </b><code>{NODE.get('name')}</code>\n<b>NODE ID : </b><code>{NODE.get('id')}</code>\n<b>NODE IP : </b><code>{NODE.get('address')}</code>\n<b>ERROR MESSAGE : </b><code>{NODE.get('message')}</code>"
                             NODE_HAVE_A_PROBLEM = True
-                            app.send_message(chat_id=BOSS_CHATID , text=TEXT , parse_mode=enums.ParseMode.HTML)
+                            for CHAT_ID in BOSS_CHATIDS:
+                                app.send_message(chat_id=CHAT_ID , text=TEXT , parse_mode=enums.ParseMode.HTML)
 
                             url = f"{PANEL_DOMAIN}/api/{NODE.get('id')}/reconnect"
                             RESPONCE = requests.get(url=URL , headers=PANEL_TOKEN , verify=False)
                             if RESPONCE.status_code == 200 :
-                                app.send_message(chat_id=BOSS_CHATID , text='<b>(Checker) ✅ Automatic reconnection!</b>' , parse_mode=enums.ParseMode.HTML)
+                                for CHAT_ID in BOSS_CHATIDS:
+                                    app.send_message(chat_id=CHAT_ID , text='<b>(Checker) ✅ Automatic reconnection!</b>' , parse_mode=enums.ParseMode.HTML)
                             else:
-                                app.send_message(chat_id=BOSS_CHATID , text='<b>(Checker) ❌ Automatic reconnection!</b>' , parse_mode=enums.ParseMode.HTML)
+                                for CHAT_ID in BOSS_CHATIDS:
+                                    app.send_message(chat_id=CHAT_ID , text='<b>(Checker) ❌ Automatic reconnection!</b>' , parse_mode=enums.ParseMode.HTML)
                                                        
 
                     if NODE_HAVE_A_PROBLEM is True :
@@ -55,6 +59,7 @@ with app :
                 time.sleep(60)
 
         except Exception as e :
-            app.send_message(chat_id=BOSS_CHATID , text=f"<b>❌ (Checker) Monitoring Error :</b>\n<pre>{str(e)}</pre>" , parse_mode=enums.ParseMode.HTML)
+            for CHAT_ID in BOSS_CHATIDS:
+                app.send_message(chat_id=CHAT_ID , text=f"<b>❌ (Checker) Monitoring Error :</b>\n<pre>{str(e)}</pre>" , parse_mode=enums.ParseMode.HTML)
             time.sleep(60)
             pass


### PR DESCRIPTION
## Summary
- support multiple boss chat IDs in database and utilities
- broadcast monitoring and message notifications to all admins
- document adding/removing admin IDs and accept multiple IDs in installer

## Testing
- `python -m py_compile Function/db.py holder.py monitoring.py expired.py limiteder.py`
- `bash -n holderbot.sh`


------
https://chatgpt.com/codex/tasks/task_b_68a06fe9c57c8329a03e1e34cbfcdace